### PR TITLE
Added support for Chinese (Traditional, Taiwan)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ For the pre-release packages, use the ForEvolve [NuGet V3 feed URL](https://www.
  - `Spanish (es)` thanks to [Oswaldo Diaz](https://github.com/OswaldoDG)
  - `Norwegian (bokmål) (nb)` thanks to [Petter Hoel](https://github.com/petterhoel) (If you are using `nb-NO` it should default to `nb`)
  - `Norwegian (bokmål) (no)` thanks to [Petter Hoel](https://github.com/petterhoel) (Same as `nb`)
+ - `Chinese (zh)` thanks to [Jay Skyworker](https://github.com/jayskyworker) (Same as `zh-TW`, needs to be checked)
+ - `Chinese Traditional (zh-Hant)` thanks to [Jay Skyworker](https://github.com/jayskyworker) (Same as `zh-TW`, needs to be checked)
+ - `Chinese Traditional, Taiwan (zh-TW)` thanks to [Jay Skyworker](https://github.com/jayskyworker)
  
 ## Supported attributes
 

--- a/src/ForEvolve.AspNetCore.Localization/Resources/DataAnnotationSharedResource.zh-Hant.resx
+++ b/src/ForEvolve.AspNetCore.Localization/Resources/DataAnnotationSharedResource.zh-Hant.resx
@@ -1,0 +1,159 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CompareAttribute_ErrorMessage" xml:space="preserve">
+    <value>'{0}' 欄位 及 '{1}' 欄位 資料不一致.</value>
+  </data>
+  <data name="CreditCardAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不是正確的信用卡卡號格式.</value>
+  </data>
+  <data name="EmailAddressAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不是正確的Email格式.</value>
+  </data>
+  <data name="FileExtensionsAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 只接受下列副檔名: {1}</value>
+  </data>
+  <data name="MaxLengthAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 長度最多為 '{1}'.</value>
+  </data>
+  <data name="MinLengthAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 長度最少為 '{1}'.</value>
+  </data>
+  <data name="PhoneAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不是正確的電話號碼格式.</value>
+  </data>
+  <data name="RangeAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 必須藉再 {1} 跟 {2} 之間.</value>
+  </data>
+  <data name="RegularExpressionAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不符合正規表式 '{1}'.</value>
+  </data>
+  <data name="RequiredAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位為必填.</value>
+  </data>
+  <data name="StringLengthAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位的長度 最長 {1} 個字元.</value>
+  </data>
+  <data name="StringLengthAttribute_ErrorMessageIncludingMinimum" xml:space="preserve">
+    <value>{0} 欄位 字元長度必須在 {2} 跟 {1} 之間.</value>
+  </data>
+  <data name="UrlAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不是一個正確的 http, https, 或 ftp 網址.</value>
+  </data>
+</root>

--- a/src/ForEvolve.AspNetCore.Localization/Resources/DataAnnotationSharedResource.zh-TW.resx
+++ b/src/ForEvolve.AspNetCore.Localization/Resources/DataAnnotationSharedResource.zh-TW.resx
@@ -1,0 +1,159 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CompareAttribute_ErrorMessage" xml:space="preserve">
+    <value>'{0}' 欄位 及 '{1}' 欄位 資料不一致.</value>
+  </data>
+  <data name="CreditCardAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不是正確的信用卡卡號格式.</value>
+  </data>
+  <data name="EmailAddressAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不是正確的Email格式.</value>
+  </data>
+  <data name="FileExtensionsAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 只接受下列副檔名: {1}</value>
+  </data>
+  <data name="MaxLengthAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 長度最多為 '{1}'.</value>
+  </data>
+  <data name="MinLengthAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 長度最少為 '{1}'.</value>
+  </data>
+  <data name="PhoneAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不是正確的電話號碼格式.</value>
+  </data>
+  <data name="RangeAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 必須藉再 {1} 跟 {2} 之間.</value>
+  </data>
+  <data name="RegularExpressionAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不符合正規表式 '{1}'.</value>
+  </data>
+  <data name="RequiredAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位為必填.</value>
+  </data>
+  <data name="StringLengthAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位的長度 最長 {1} 個字元.</value>
+  </data>
+  <data name="StringLengthAttribute_ErrorMessageIncludingMinimum" xml:space="preserve">
+    <value>{0} 欄位 字元長度必須在 {2} 跟 {1} 之間.</value>
+  </data>
+  <data name="UrlAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不是一個正確的 http, https, 或 ftp 網址.</value>
+  </data>
+</root>

--- a/src/ForEvolve.AspNetCore.Localization/Resources/DataAnnotationSharedResource.zh.resx
+++ b/src/ForEvolve.AspNetCore.Localization/Resources/DataAnnotationSharedResource.zh.resx
@@ -1,0 +1,159 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="CompareAttribute_ErrorMessage" xml:space="preserve">
+    <value>'{0}' 欄位 及 '{1}' 欄位 資料不一致.</value>
+  </data>
+  <data name="CreditCardAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不是正確的信用卡卡號格式.</value>
+  </data>
+  <data name="EmailAddressAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不是正確的Email格式.</value>
+  </data>
+  <data name="FileExtensionsAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 只接受下列副檔名: {1}</value>
+  </data>
+  <data name="MaxLengthAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 長度最多為 '{1}'.</value>
+  </data>
+  <data name="MinLengthAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 長度最少為 '{1}'.</value>
+  </data>
+  <data name="PhoneAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不是正確的電話號碼格式.</value>
+  </data>
+  <data name="RangeAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 必須藉再 {1} 跟 {2} 之間.</value>
+  </data>
+  <data name="RegularExpressionAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不符合正規表式 '{1}'.</value>
+  </data>
+  <data name="RequiredAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位為必填.</value>
+  </data>
+  <data name="StringLengthAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位的長度 最長 {1} 個字元.</value>
+  </data>
+  <data name="StringLengthAttribute_ErrorMessageIncludingMinimum" xml:space="preserve">
+    <value>{0} 欄位 字元長度必須在 {2} 跟 {1} 之間.</value>
+  </data>
+  <data name="UrlAttribute_ErrorMessage" xml:space="preserve">
+    <value>{0} 欄位 不是一個正確的 http, https, 或 ftp 網址.</value>
+  </data>
+</root>

--- a/src/ForEvolve.AspNetCore.Localization/StartupExtensions.cs
+++ b/src/ForEvolve.AspNetCore.Localization/StartupExtensions.cs
@@ -52,6 +52,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 new CultureInfo("es"),
                 new CultureInfo("no"),
                 new CultureInfo("nb"),
+                new CultureInfo("zh"),
+                new CultureInfo("zh-Hant"),
+                new CultureInfo("zh-TW"),
             });
             var defaultCulture = supportedCultures.First();
             var localizationOptions = new ForEvolveLocalizationOptions


### PR DESCRIPTION
Hi,
Please consider this addition of support for the Chinese (Traditional, Taiwan) **zh-TW**.

I did added two Neutral Cultures:
Chinese **zh**
Chinese (Traditional) **zh-Hant**

with same content as **zh-TW**
But I can't do Chinese (Simplified) **zh-Hans**,
**zh-Hans** and Chinese (Simplified, China) **zh-CN**, might fall back to **zh**,
which they might have a harder time understanding it.

my suggestion is to remove **zh**.

Thanks for the Great project! 